### PR TITLE
setup URL crawl

### DIFF
--- a/queries/crawler.py
+++ b/queries/crawler.py
@@ -3,7 +3,7 @@ import os
 from functools import partial
 from pathlib import Path
 from queue import Empty
-from typing import Dict
+from typing import Dict, List
 
 import duckdb
 import pandas as pd
@@ -27,8 +27,12 @@ class Crawler:
         self.error_path = self.data_path / "error.csv"
         self.output_path = self.data_path / "output.csv"
 
-    def initialize_crawler(self):
+    def initialize_crawler(self) -> bool:
         """Set up crawler file structure"""
+        if self.data_path.exists():
+            print(f"Crawler for {self.crawl_name} already initialized, skipping...")
+            return False
+
         self.data_path.mkdir(parents=True, exist_ok=True)
 
         # Create empty to_crawl.csv with columns
@@ -45,6 +49,8 @@ class Crawler:
         # Create empty output.csv with columns
         pd.DataFrame(columns=["dataset", "url"]).to_csv(self.output_path, index=False)
 
+        return True
+
     def populate_hf(self, patterns: Dict[str, str]):
         """Populate data from Hugging Face datasets"""
         load_dotenv()
@@ -56,7 +62,7 @@ class Crawler:
             df = pd.DataFrame({"dataset": dataset, "file": files})
             df.to_csv(self.to_crawl_path, index=False, mode="a", header=False)
 
-    def populate_other(self, data: Dict[str, str]):
+    def populate_other(self, data: Dict[str, List[str]]):
         """Populate data from other sources"""
         for dataset, files in data.items():
             df = pd.DataFrame({"dataset": dataset, "file": files})

--- a/queries/url_collection.py
+++ b/queries/url_collection.py
@@ -1,0 +1,30 @@
+from crawler import Crawler
+
+patterns_hf = {
+    "c4_en": "hf://datasets/allenai/c4/en/*.json.gz",
+    "c4_en_noblock": "hf://datasets/allenai/c4/en.noblocklist/*.json.gz",
+    "c4_multilingual": "hf://datasets/allenai/c4/multilingual/*.json.gz",
+    "c4_news": "hf://datasets/allenai/c4/realnewslike/*.json.gz",
+    "cultura": "hf://datasets/uonlp/CulturaX/*/*.parquet",
+    "falcon": "hf://datasets/tiiuae/falcon-refinedweb/data/*.parquet",
+    "fineweb": "hf://datasets/HuggingFaceFW/fineweb/data/*/*.parquet",
+    "fineweb_edu": "hf://datasets/HuggingFaceFW/fineweb-edu/data/*/*.parquet",
+    "madlad_cleaned": "hf://datasets/allenai/MADLAD-400/data-v1p5/*/clean*.jsonl.gz",
+    "madlad_noisy": "hf://datasets/allenai/MADLAD-400/data-v1p5/*/noisy*.jsonl.gz",
+    "zyda_2": "hf://datasets/Zyphra/Zyda-2/data/**/*.parquet",
+    "dclm": "hf://datasets/mlfoundations/dclm-baseline-1.0-parquet/filtered/**/*.parquet",
+}
+
+with open("./data/dolma_urls.txt", "r") as f:
+    data_other = {"dolma": f.readlines()}
+
+
+url_crawler = Crawler("urls")
+
+needs_populated = url_crawler.initialize_crawler()
+if needs_populated:
+    url_crawler.populate_hf(patterns_hf)
+    url_crawler.populate_other(data_other)
+
+# Run the crawler
+url_crawler.crawl()


### PR DESCRIPTION
This pull request includes several enhancements and new features to the `queries` module, specifically targeting the `crawler.py` and `url_collection.py` files. The changes include improvements to type annotations, the addition of a new method, and the introduction of a new script to run the crawler.

### Enhancements to `queries/crawler.py`:

* Added `List` to the import statement to improve type annotations.
* Modified `initialize_crawler` method to return a boolean indicating whether initialization was necessary and added a check to skip initialization if already done. [[1]](diffhunk://#diff-1e6b0ec2bac3f77563d6b7daee3063f1ea11019ffe55d3418b1f9b3379dd4394L30-R35) [[2]](diffhunk://#diff-1e6b0ec2bac3f77563d6b7daee3063f1ea11019ffe55d3418b1f9b3379dd4394R52-R53)
* Updated `populate_other` method to accept a dictionary with lists of strings as values, improving type safety.

### New script in `queries/url_collection.py`:

* Introduced a new script to run the crawler, including the definition of patterns for Hugging Face datasets and reading additional data from a file.