### PR TITLE
SQL + bash analysis pipeline

### DIFF
--- a/analysis/pipeline_sketch.ipynb
+++ b/analysis/pipeline_sketch.ipynb
@@ -1,0 +1,97 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import duckdb"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "con = duckdb.connect()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dataset_path = \"hf://datasets/nhagar/c4_en_urls/data/*.parquet\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[(365233500,)]"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "con.execute(f\"SELECT COUNT(*) FROM read_parquet('{dataset_path}')\").fetchall()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "con.execute(f\"SELECT split_part(url, '/', 3) as domain, COUNT(*) as count FROM read_parquet('{dataset_path}') GROUP BY domain ORDER BY count DESC LIMIT 10\").fetchall()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "con.execute(f\"SELECT url FROM read_parquet('{dataset_path}') WHERE CONTAINS(url, 'nytimes.com') LIMIT 10\").fetchall()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "cc",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/analysis_pipeline.sh
+++ b/analysis_pipeline.sh
@@ -9,9 +9,22 @@ fi
 # Store dataset path from command line argument
 DATASET=$1
 
-# Execute DuckDB query
-# Replace the SELECT query with your specific query
-duckdb  :memory: "COPY (SELECT url FROM read_parquet('$DATASET') LIMIT 5) TO 'test.csv';"
+# Top-level count
+duckdb  :memory: "COPY (SELECT url FROM read_parquet('$DATASET') LIMIT 5) TO 'test_count.csv';"
+
+# Create temporary table with domain counts
+DOMAIN_COUNTS="domain_counts.csv"
+duckdb :memory: "COPY (SELECT split_part(url, '/', 3) as domain, COUNT(*) as count FROM read_parquet('$DATASET') GROUP BY domain ORDER BY count DESC) TO '$DOMAIN_COUNTS';"
+
+# Run stratified sample with parameters
+SAMPLE_OUTPUT="stratified_sample.csv"
+duckdb :memory: -init queries/analysis/stratified_sample.sql "$DOMAIN_COUNTS" "$SAMPLE_OUTPUT"
+
+# Cleanup
+rm "$DOMAIN_COUNTS"
+
+# Case study search
+duckdb  :memory: "COPY (SELECT url FROM read_parquet('$DATASET') WHERE CONTAINS(url, 'nytimes.com') LIMIT 5) TO 'test_nyt.csv';"
 
 # Exit with success status
 exit 0

--- a/analysis_pipeline.sh
+++ b/analysis_pipeline.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# Check if dataset argument is provided
+if [ $# -ne 1 ]; then
+    echo "Usage: $0 <dataset_path>"
+    exit 1
+fi
+
+# Store dataset path from command line argument
+DATASET=$1
+
+# Execute DuckDB query
+# Replace the SELECT query with your specific query
+duckdb  :memory: "COPY (SELECT url FROM read_parquet('$DATASET') LIMIT 5) TO 'test.csv';"
+
+# Exit with success status
+exit 0

--- a/analysis_pipeline.sh
+++ b/analysis_pipeline.sh
@@ -1,30 +1,11 @@
-#!/bin/bash
-
-# Check if dataset argument is provided
-if [ $# -ne 1 ]; then
-    echo "Usage: $0 <dataset_path>"
-    exit 1
-fi
-
-# Store dataset path from command line argument
-DATASET=$1
-
+# !/bin/bash
 # Top-level count
-duckdb  :memory: "COPY (SELECT url FROM read_parquet('$DATASET') LIMIT 5) TO 'test_count.csv';"
-
-# Create temporary table with domain counts
-DOMAIN_COUNTS="domain_counts.csv"
-duckdb :memory: "COPY (SELECT split_part(url, '/', 3) as domain, COUNT(*) as count FROM read_parquet('$DATASET') GROUP BY domain ORDER BY count DESC) TO '$DOMAIN_COUNTS';"
-
-# Run stratified sample with parameters
-SAMPLE_OUTPUT="stratified_sample.csv"
-duckdb :memory: -init queries/analysis/stratified_sample.sql "$DOMAIN_COUNTS" "$SAMPLE_OUTPUT"
-
-# Cleanup
-rm "$DOMAIN_COUNTS"
-
+duckdb < queries/analysis/top_level_count.sql
+# Domain counts
+duckdb < queries/analysis/domain_counts.sql
+# Stratified sample
+duckdb < queries/analysis/stratified_sample.sql
 # Case study search
-duckdb  :memory: "COPY (SELECT url FROM read_parquet('$DATASET') WHERE CONTAINS(url, 'nytimes.com') LIMIT 5) TO 'test_nyt.csv';"
+duckdb < queries/analysis/case_studies.sql
 
-# Exit with success status
 exit 0

--- a/queries/analysis/case_studies.sql
+++ b/queries/analysis/case_studies.sql
@@ -1,0 +1,8 @@
+COPY (
+    SELECT 
+        url 
+    FROM 
+        read_parquet('hf://datasets/nhagar/c4_en_urls/data/*.parquet') 
+    WHERE 
+        CONTAINS(url, 'nytimes.com') LIMIT 5) 
+TO 'c4_en_urls_casestudies.csv';

--- a/queries/analysis/domain_counts.sql
+++ b/queries/analysis/domain_counts.sql
@@ -1,0 +1,9 @@
+COPY (
+    SELECT 
+        split_part(url, '/', 3) as domain, 
+        COUNT(*) as freq 
+    FROM read_parquet('hf://datasets/nhagar/c4_en_urls/data/*.parquet') 
+    GROUP BY domain 
+    ORDER BY freq DESC
+) 
+TO 'c4_en_urls_domains.csv';

--- a/queries/analysis/stratified_sample.sql
+++ b/queries/analysis/stratified_sample.sql
@@ -1,0 +1,29 @@
+COPY (WITH buckets AS (
+  SELECT 
+    domain,
+    count,
+    CASE 
+      WHEN count BETWEEN 1 AND 10 THEN '1-10'
+      WHEN count BETWEEN 11 AND 100 THEN '11-100'
+      WHEN count BETWEEN 101 AND 1000 THEN '101-1000'
+      ELSE '1000+'
+    END AS count_bucket
+  FROM $1
+),
+random_samples AS (
+  SELECT 
+    domain,
+    count,
+    count_bucket,
+    ROW_NUMBER() OVER (
+      PARTITION BY count_bucket 
+      ORDER BY RANDOM()
+    ) as rn
+  FROM buckets
+)
+SELECT 
+  domain,
+  count,
+  count_bucket
+FROM random_samples
+WHERE rn <= 10) TO $2;

--- a/queries/analysis/stratified_sample.sql
+++ b/queries/analysis/stratified_sample.sql
@@ -1,11 +1,11 @@
 COPY (WITH buckets AS (
   SELECT 
     domain,
-    count,
+    freq,
     CASE 
-      WHEN count BETWEEN 1 AND 10 THEN '1-10'
-      WHEN count BETWEEN 11 AND 100 THEN '11-100'
-      WHEN count BETWEEN 101 AND 1000 THEN '101-1000'
+      WHEN freq BETWEEN 1 AND 10 THEN '1-10'
+      WHEN freq BETWEEN 11 AND 100 THEN '11-100'
+      WHEN freq BETWEEN 101 AND 1000 THEN '101-1000'
       ELSE '1000+'
     END AS count_bucket
   FROM 'c4_en_urls_domains.csv'
@@ -13,7 +13,7 @@ COPY (WITH buckets AS (
 random_samples AS (
   SELECT 
     domain,
-    count,
+    freq,
     count_bucket,
     ROW_NUMBER() OVER (
       PARTITION BY count_bucket 
@@ -23,7 +23,7 @@ random_samples AS (
 )
 SELECT 
   domain,
-  count,
+  freq,
   count_bucket
 FROM random_samples
 WHERE rn <= 100) TO 'c4_en_urls_sample.csv';

--- a/queries/analysis/stratified_sample.sql
+++ b/queries/analysis/stratified_sample.sql
@@ -8,7 +8,7 @@ COPY (WITH buckets AS (
       WHEN count BETWEEN 101 AND 1000 THEN '101-1000'
       ELSE '1000+'
     END AS count_bucket
-  FROM $1
+  FROM 'c4_en_urls_domains.csv'
 ),
 random_samples AS (
   SELECT 
@@ -26,4 +26,4 @@ SELECT
   count,
   count_bucket
 FROM random_samples
-WHERE rn <= 10) TO $2;
+WHERE rn <= 100) TO 'c4_en_urls_sample.csv';

--- a/queries/analysis/top_level_count.sql
+++ b/queries/analysis/top_level_count.sql
@@ -1,0 +1,7 @@
+COPY (
+    SELECT 
+        COUNT(*) AS total_count
+    FROM 
+        read_parquet('hf://datasets/nhagar/c4_en_urls/data/*.parquet')
+) 
+TO 'c4_en_urls_count.csv';


### PR DESCRIPTION
This pull request introduces a new analysis pipeline using DuckDB to process and analyze a dataset of URLs stored in Parquet files. The changes include the addition of a Jupyter notebook, a shell script, and several SQL query files.

### New Analysis Pipeline:

* [`analysis/pipeline_sketch.ipynb`](diffhunk://#diff-1d9596a170f754fb8698396146da776d25ba00953d5181eb9cd8c412f50baa90R1-R97): Added a Jupyter notebook to demonstrate the use of DuckDB for loading and querying the dataset. The notebook includes code for connecting to DuckDB, counting rows, and performing various queries on the dataset.
* [`analysis_pipeline.sh`](diffhunk://#diff-9706c5905dabda17623cacc4226239bc720e4998e1190101ddbae8e2d5bddbdcR1-R11): Added a shell script to automate the execution of SQL queries using DuckDB. This script runs queries for top-level counts, domain counts, stratified samples, and case studies.

### SQL Queries for Analysis:

* [`queries/analysis/top_level_count.sql`](diffhunk://#diff-0d20c462455b6e5d093a46e749bbc26277c022b93070aa942a7a09b35547535fR1-R7): Added a SQL query to count the total number of rows in the dataset and export the result to a CSV file.
* [`queries/analysis/domain_counts.sql`](diffhunk://#diff-2158ddfd2078f8183c4e75867e9e708eba0e7b11c274bcbd55a906821a174122R1-R9): Added a SQL query to count the occurrences of each domain in the dataset and export the results to a CSV file.
* [`queries/analysis/stratified_sample.sql`](diffhunk://#diff-0a479cfbc47f31101ef348ecebb4556ab3f32cd24222ea8fa9016c4ceda02074R1-R29): Added a SQL query to generate a stratified sample of domains based on their frequency and export the results to a CSV file.
* [`queries/analysis/case_studies.sql`](diffhunk://#diff-b162376b8d43dcb8795d17ec08346a4030637b19f24ce8ed049694758863305dR1-R8): Added a SQL query to extract URLs containing 'nytimes.com' and export the results to a CSV file.