### PR TITLE
Rewrite file operations

### DIFF
--- a/data_export.sh
+++ b/data_export.sh
@@ -13,4 +13,4 @@ module load mamba
 source ~/.bashrc
 mamba activate /home/nrh146/.conda/envs/cc
 
-python -u ./queries/upload_to_hf.py --dataset fineweb --scratch
+python -u ./queries/upload_to_hf.py --dataset fineweb --scratch --large

--- a/queries/file_operations.py
+++ b/queries/file_operations.py
@@ -12,7 +12,6 @@ def upload_directory_to_hf(
     dataset_name: str,
     token: str,
     is_large: bool = True,
-    private: bool = False,
 ) -> None:
     """
     Uploads a directory of parquet files as a HuggingFace dataset.
@@ -22,7 +21,6 @@ def upload_directory_to_hf(
         dataset_name (str): Name to give the dataset on HuggingFace
         token (str, optional): HuggingFace API token. Defaults to None.
         is_large (bool, optional): Whether the dataset is large. Defaults to True.
-        private (bool, optional): Whether to make the dataset private. Defaults to False.
     """
 
     # check for parquet files in directory
@@ -35,7 +33,7 @@ def upload_directory_to_hf(
             f"nhagar/{dataset_name}",
             token=token,
             repo_type="dataset",
-            private=private,
+            private=False,
         )
 
         api.upload_folder(
@@ -62,7 +60,6 @@ def upload_file_to_hf(
     dataset_name: str,
     token: str,
     convert_csv_to_parquet: bool = True,
-    private: bool = False,
 ) -> None:
     """
     Uploads a single file as a HuggingFace dataset.
@@ -80,6 +77,19 @@ def upload_file_to_hf(
         df.to_parquet(parquet_path, index=False, compression="brotli")
         file_path = parquet_path
 
-    dataset = load_dataset("parquet", data_files=file_path)
-    dataset.push_to_hub(dataset_name, token=token, private=private)
+    api.create_repo(
+        f"nhagar/{dataset_name}",
+        token=token,
+        repo_type="dataset",
+        private=False,
+    )
+
+    api.upload_file(
+        path_or_fileobj=file_path,
+        path_in_repo="data",
+        repo_id=f"nhagar/{dataset_name}",
+        token=token,
+        repo_type="dataset",
+    )
+
     print(f"Successfully uploaded {file_path} as {dataset_name}")

--- a/queries/upload_to_hf.py
+++ b/queries/upload_to_hf.py
@@ -9,6 +9,7 @@ load_dotenv()
 parser = ArgumentParser()
 parser.add_argument("--dataset", type=str, required=True)
 parser.add_argument("--scratch", action="store_true")
+parser.add_argument("--large", action="store_true")
 
 if __name__ == "__main__":
     args = parser.parse_args()
@@ -25,4 +26,5 @@ if __name__ == "__main__":
         directory,
         f"nhagar/{args.dataset}_urls",
         token=token,
+        is_large=args.large,
     )

--- a/queries/upload_to_hf.py
+++ b/queries/upload_to_hf.py
@@ -2,37 +2,27 @@ import os
 from argparse import ArgumentParser
 
 from dotenv import load_dotenv
-from file_operations import upload_directory_to_hf, upload_file_to_hf
+from file_operations import upload_directory_to_hf
 
 load_dotenv()
 
 parser = ArgumentParser()
 parser.add_argument("--dataset", type=str, required=True)
-parser.add_argument("--is_file", action="store_true")
 parser.add_argument("--scratch", action="store_true")
 
 if __name__ == "__main__":
     args = parser.parse_args()
 
-    if args.is_file:
-        file_path = f"./data/commoncrawl/{args.dataset}.csv"
-        upload_file_to_hf(
-            file_path,
-            f"nhagar/{args.dataset}_urls",
-            token=os.getenv("HF_TOKEN_WRITE"),
-            private=True,
-            convert_csv_to_parquet=True,
-        )
+    token = os.getenv("HF_TOKEN_WRITE")
+    if not token:
+        raise ValueError("Hugging Face API token not found")
 
+    if args.scratch:
+        directory = f"/scratch/nrh146/dataset={args.dataset}"
     else:
-        if args.scratch:
-            directory = f"/scratch/nrh146/dataset={args.dataset}"
-        else:
-            directory = f"./data/urls/output/dataset={args.dataset}"
-        upload_directory_to_hf(
-            directory,
-            f"nhagar/{args.dataset}_urls",
-            token=os.getenv("HF_TOKEN_WRITE"),
-            private=False,
-            use_scratch_cache=args.scratch,
-        )
+        directory = f"./data/urls/output/dataset={args.dataset}"
+    upload_directory_to_hf(
+        directory,
+        f"nhagar/{args.dataset}_urls",
+        token=token,
+    )


### PR DESCRIPTION
This pull request focuses on updating the data export process to handle large datasets more effectively and removing the option to upload individual files. The most important changes include modifying the `upload_directory_to_hf` function to handle large datasets, removing the `upload_file_to_hf` function, and updating the script arguments to reflect these changes.

Changes to handle large datasets:

* [`queries/file_operations.py`](diffhunk://#diff-af2b616a3d025f79ef5976a58fb65ffcf229c18787096957a859a052fc9d0cb7L5-R14): Modified the `upload_directory_to_hf` function to include a new `is_large` parameter, which defaults to `True`. The function now uses the `HfApi` to create and upload datasets, with different handling for large datasets. [[1]](diffhunk://#diff-af2b616a3d025f79ef5976a58fb65ffcf229c18787096957a859a052fc9d0cb7L5-R14) [[2]](diffhunk://#diff-af2b616a3d025f79ef5976a58fb65ffcf229c18787096957a859a052fc9d0cb7L22-R53)

Removal of file upload functionality:

* [`queries/file_operations.py`](diffhunk://#diff-af2b616a3d025f79ef5976a58fb65ffcf229c18787096957a859a052fc9d0cb7L55): Removed the `upload_file_to_hf` function and all related code. [[1]](diffhunk://#diff-af2b616a3d025f79ef5976a58fb65ffcf229c18787096957a859a052fc9d0cb7L55) [[2]](diffhunk://#diff-af2b616a3d025f79ef5976a58fb65ffcf229c18787096957a859a052fc9d0cb7L73-R94)
* [`queries/upload_to_hf.py`](diffhunk://#diff-ff1af25026b1d6444afcc5e652f1ca91fb4d638415aeaa9982e4c7f1d5689595L5-R29): Removed the `--is_file` argument and all related code, as the script no longer supports uploading individual files.

Script argument updates:

* [`data_export.sh`](diffhunk://#diff-9d4bae39ead8cc5ad7692dec76ff1337fa3b284ac99f9582e4e91239e6298e3cL16-R16): Updated the script to include the `--large` argument when calling the `upload_to_hf.py` script.
* [`queries/upload_to_hf.py`](diffhunk://#diff-ff1af25026b1d6444afcc5e652f1ca91fb4d638415aeaa9982e4c7f1d5689595L5-R29): Added the `--large` argument to specify if the dataset is large.